### PR TITLE
fix(infrastructure): add vault connection ref

### DIFF
--- a/infrastructure/vault/vault-auth.yaml
+++ b/infrastructure/vault/vault-auth.yaml
@@ -4,6 +4,7 @@ metadata:
   name: static-auth
   namespace: vault-secrets-operator-system
 spec:
+  vaultConnectionRef: default
   method: kubernetes
   mount: kubernetes
   kubernetes:
@@ -11,3 +12,4 @@ spec:
     serviceAccount: default
     audiences:
       - vault
+    tokenExpirationSeconds: 600 # 10 minutes


### PR DESCRIPTION
This field must reference an existing `VaultConnection` custom resource in your cluster that defines how to connect to your Vault server.